### PR TITLE
decouple core module

### DIFF
--- a/packages/next-starter/src/app/components/MyApp.tsx
+++ b/packages/next-starter/src/app/components/MyApp.tsx
@@ -1,14 +1,14 @@
 import '../../assets/styles.less';
 import '../../assets/tailwind-extension.css';
 
-import App, { AppContext } from 'next/app';
-import React from 'react';
+import { AppContext } from 'next/app';
+import React, { Component } from 'react';
 import { MakeStore, createWrapper, Context } from 'next-redux-wrapper';
 import Head from 'next/head';
-import Router, { useRouter } from 'next/router';
-import NProgress from 'nprogress';
+import Router from 'next/router';
+import { start, done } from 'nprogress';
 
-import { Page, GlobalStyles, AppProvider } from '@onr/core';
+import { GlobalStyles, AppProvider } from '@onr/core';
 import { store, afterComponentDidMount } from '../redux';
 
 import { PageContainer } from './PageContainer';
@@ -17,17 +17,17 @@ const makeStore: MakeStore = (context: Context) => store();
 
 const wrapper = createWrapper(makeStore, { debug: false });
 
-Router.events.on('routeChangeStart', () => NProgress.start());
-Router.events.on('routeChangeComplete', () => NProgress.done());
-Router.events.on('routeChangeError', () => NProgress.done());
+Router.events.on('routeChangeStart', () => start());
+Router.events.on('routeChangeComplete', () => done());
+Router.events.on('routeChangeError', () => done());
 Router.events.on(
   'routeChangeComplete',
   () =>
     document.querySelector('.workspace > .ant-layout') &&
-    (document.querySelector('.workspace > .ant-layout')!.scrollTop = 0),
+    (document.querySelector('.workspace > .ant-layout')!.scrollTop = 0)
 );
 
-export class AppComponent extends React.Component {
+export class AppComponent extends Component {
   // NOTE: In order to get runtime config. We will need to use getInitialProps. But the down side
   //       is it will opt out Next.js default static optimization.
   // Please refer to https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration
@@ -76,9 +76,6 @@ export class AppComponent extends React.Component {
         </Head>
         <AppProvider>
           <PageContainer {...this.props} />
-          {/*<AuthenticationProvider>
-            <PageContainer {...this.props}></PageContainer>
-          </AuthenticationProvider>*/}
         </AppProvider>
       </>
     );

--- a/packages/next-starter/src/app/components/PageContainer.tsx
+++ b/packages/next-starter/src/app/components/PageContainer.tsx
@@ -4,25 +4,23 @@ import { useDispatch } from 'react-redux';
 import { menuItems } from '../';
 import { Page } from '@onr/core';
 import { AuthWrapper } from '@onr/auth';
+import { AccountSelector } from '@onr/account';
 
-const Container: React.FC = (props) => {
+const Container: React.FC = props => {
   const { Component, pageProps } = props;
 
   return (
-    <Page 
-      {...props}
-      menuItems={menuItems} 
-    >
-      <Component {...pageProps}/>
+    <Page {...props} menuItems={menuItems} HeaderMainSection={AccountSelector}>
+      <Component {...pageProps} />
     </Page>
   );
 };
 
-export const PageContainer: React.FC = (props) => {
+export const PageContainer: React.FC = props => {
   //wrap root providers here, if any
   return (
     <AuthWrapper>
-      <Container {...props}/>
+      <Container {...props} />
     </AuthWrapper>
-  )
-}
+  );
+};

--- a/packages/next-starter/src/modules/account/components/AccountSelector.tsx
+++ b/packages/next-starter/src/modules/account/components/AccountSelector.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from 'react';
+import { Select, message } from 'antd';
+import Router from 'next/router';
+import { useDispatch, useSelector } from 'react-redux';
+import { IAccount } from '@onr/account';
+import { wrapperActions, IStore } from '@onr/core';
+
+export const AccountSelector: React.FC = () => {
+  const dispatch = useDispatch();
+  const [accounts, setAccounts] = React.useState<IAccount[]>([]);
+  const accountId = useSelector((store: IStore) => store.wrapper.accountId);
+  const currentUser = useSelector((store: IStore) => store.authStore.currentUser);
+  const setAccountId = dispatch(wrapperActions.setAccountId);
+
+  useEffect(() => {
+    if (currentUser.accounts) {
+      setAccounts(currentUser.accounts);
+
+      if (accounts[0] && !accountId) {
+        changeAccount(accounts[0].id);
+      }
+    }
+  }, [currentUser.accounts]);
+
+  function changeAccount(accountId: number) {
+    setAccountId(accountId);
+    Router.push('/');
+    message.info('Account has been changed');
+  }
+
+  return (
+    <>
+      <Select
+        showSearch
+        style={{ width: 200 }}
+        optionFilterProp="children"
+        onChange={changeAccount}
+        value={accountId}
+        filterOption={(input, option) =>
+          option.props.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+        }
+      >
+        {accounts.map(account => (
+          <Select.Option key={account.id} value={account.id}>
+            {account.id} | {account.name}
+          </Select.Option>
+        ))}
+      </Select>
+    </>
+  );
+};

--- a/packages/next-starter/src/modules/account/components/index.ts
+++ b/packages/next-starter/src/modules/account/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Accountable';
 export * from './AccountForm';
 export * from './AccountList';
+export * from './AccountSelector';
 export * from './CreateAccountForm';
 export * from './UpdateAccountForm';

--- a/packages/next-starter/src/modules/core/components/Header.tsx
+++ b/packages/next-starter/src/modules/core/components/Header.tsx
@@ -7,11 +7,14 @@ import Link from 'next/link';
 import { wrapperActions, IStore } from '@onr/core';
 
 import DashHeader from './styles/Header';
-import { AccountSelector } from '@onr/account';
 
 const { SubMenu } = Menu;
 
-export const Header: React.FC = () => {
+type Props = {
+  HeaderMainSection: React.Component;
+};
+
+export const Header: React.FC = ({ HeaderMainSection }: Props) => {
   const dispatch = useDispatch();
   const { name, mobile } = useSelector((store: IStore) => store.wrapper);
 
@@ -30,10 +33,9 @@ export const Header: React.FC = () => {
           </a>
         </Link>
 
-        <AccountSelector />
+        <HeaderMainSection />
 
         <span className="mr-auto" />
-
         <Menu mode="horizontal">
           <Menu.Item onClick={() => dispatch(wrapperActions.setOptionDrawer())}>
             <Settings size={20} strokeWidth={1} />

--- a/packages/next-starter/src/modules/core/components/Header.tsx
+++ b/packages/next-starter/src/modules/core/components/Header.tsx
@@ -1,33 +1,32 @@
 import React from 'react';
 import { Avatar, Layout, Menu } from 'antd';
 import { BarChart, Settings, Triangle } from 'react-feather';
+import { useDispatch, useSelector } from 'react-redux';
 import Link from 'next/link';
-import { connect } from 'react-redux';
-import { bindActionCreators, Dispatch } from 'redux';
 
-import { wrapperActions, IWrapperPage, IStore } from '@onr/core';
+import { wrapperActions, IStore } from '@onr/core';
 
 import DashHeader from './styles/Header';
 import { AccountSelector } from '@onr/account';
 
 const { SubMenu } = Menu;
 
-const MainHeader = (props: IWrapperPage.IProps) => {
-  const { setOptionDrawer, setMobileDrawer } = props;
-  const state = props;
+export const Header: React.FC = () => {
+  const dispatch = useDispatch();
+  const { name, mobile } = useSelector((store: IStore) => store.wrapper);
 
   return (
     <DashHeader>
       <Layout.Header>
-        {state.mobile && (
-          <a onClick={() => setMobileDrawer()} className="trigger">
+        {mobile && (
+          <a onClick={() => dispatch(wrapperActions.setMobileDrawer())} className="trigger">
             <BarChart size={20} strokeWidth={1} />
           </a>
         )}
         <Link href="/">
           <a className="brand">
             <Triangle size={24} strokeWidth={1} />
-            <strong className="mx-1 text-black">{state.name}</strong>
+            <strong className="mx-1 text-black">{name}</strong>
           </a>
         </Link>
 
@@ -36,7 +35,7 @@ const MainHeader = (props: IWrapperPage.IProps) => {
         <span className="mr-auto" />
 
         <Menu mode="horizontal">
-          <Menu.Item onClick={() => setOptionDrawer()}>
+          <Menu.Item onClick={() => dispatch(wrapperActions.setOptionDrawer())}>
             <Settings size={20} strokeWidth={1} />
           </Menu.Item>
 
@@ -53,12 +52,3 @@ const MainHeader = (props: IWrapperPage.IProps) => {
     </DashHeader>
   );
 };
-
-const mapStateToProps = (state: IStore) => state.wrapper;
-
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  setOptionDrawer: bindActionCreators(wrapperActions.setOptionDrawer, dispatch),
-  setMobileDrawer: bindActionCreators(wrapperActions.setMobileDrawer, dispatch),
-});
-
-export const Header = connect(mapStateToProps, mapDispatchToProps)(MainHeader);

--- a/packages/next-starter/src/modules/core/components/Header.tsx
+++ b/packages/next-starter/src/modules/core/components/Header.tsx
@@ -1,34 +1,20 @@
-import React, { useEffect } from 'react';
-import { useSelector } from 'react-redux';
-import { Avatar, Layout, Menu, Select, message } from 'antd';
+import React from 'react';
+import { Avatar, Layout, Menu } from 'antd';
 import { BarChart, Settings, Triangle } from 'react-feather';
 import Link from 'next/link';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
-import Router from 'next/router';
 
 import { wrapperActions, IWrapperPage, IStore } from '@onr/core';
-import { IAccount } from '@onr/account';
 
 import DashHeader from './styles/Header';
+import { AccountSelector } from '@onr/account';
 
 const { SubMenu } = Menu;
 
 const MainHeader = (props: IWrapperPage.IProps) => {
-  const { setOptionDrawer, setMobileDrawer, setAccountId } = props;
+  const { setOptionDrawer, setMobileDrawer } = props;
   const state = props;
-  const currentUser = useSelector((store: IStore) => store.authStore.currentUser);
-  const [accounts, setAccounts] = React.useState<IAccount[]>([]);
-
-  useEffect(() => {
-    if (currentUser.accounts) {
-      setAccounts(currentUser.accounts);
-
-      if (accounts[0] && !state.accountId) {
-        changeAccount(accounts[0].id);
-      }
-    }
-  }, [currentUser.accounts]);
 
   return (
     <DashHeader>
@@ -45,22 +31,7 @@ const MainHeader = (props: IWrapperPage.IProps) => {
           </a>
         </Link>
 
-        <Select
-          showSearch
-          style={{ width: 200 }}
-          optionFilterProp="children"
-          onChange={changeAccount}
-          value={state.accountId}
-          filterOption={(input, option) =>
-            option.props.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
-          }
-        >
-          {accounts.map(account => (
-            <Select.Option key={account.id} value={account.id}>
-              {account.id} | {account.name}
-            </Select.Option>
-          ))}
-        </Select>
+        <AccountSelector />
 
         <span className="mr-auto" />
 
@@ -81,12 +52,6 @@ const MainHeader = (props: IWrapperPage.IProps) => {
       </Layout.Header>
     </DashHeader>
   );
-
-  function changeAccount(accountId: number) {
-    setAccountId(accountId);
-    Router.push('/');
-    message.info('Account has been changed');
-  }
 };
 
 const mapStateToProps = (state: IStore) => state.wrapper;
@@ -94,7 +59,6 @@ const mapStateToProps = (state: IStore) => state.wrapper;
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   setOptionDrawer: bindActionCreators(wrapperActions.setOptionDrawer, dispatch),
   setMobileDrawer: bindActionCreators(wrapperActions.setMobileDrawer, dispatch),
-  setAccountId: bindActionCreators(wrapperActions.setAccountId, dispatch),
 });
 
 export const Header = connect(mapStateToProps, mapDispatchToProps)(MainHeader);

--- a/packages/next-starter/src/modules/core/components/Page.tsx
+++ b/packages/next-starter/src/modules/core/components/Page.tsx
@@ -23,7 +23,7 @@ const NonDashboardRoutes = [
 ];
 /* eslint-disable complexity */
 export const Page = (props: IWrapperPage.IProps) => {
-  const { menuItems, children } = props;
+  const { HeaderMainSection, menuItems, children } = props;
   const router = useRouter();
   const currentUser = useSelector((store: IStore) => store.authStore.currentUser);
   const { boxed, darkSidebar, sidebarPopup, weakColor } = useSelector(
@@ -42,7 +42,7 @@ export const Page = (props: IWrapperPage.IProps) => {
     <Spin tip="Loading..." size="large" spinning={loading}>
       <ThemeProvider theme={theme}>
         <Container className={`${weakColor ? 'weakColor' : ''} ${boxed ? 'boxed shadow-sm' : ''}`}>
-          {!isNotDashboard && <Header {...props} />}
+          {!isNotDashboard && <Header HeaderMainSection={HeaderMainSection} />}
           <Layout className="workspace">
             {!isNotDashboard && (
               <SidebarMenu

--- a/packages/next-starter/src/modules/core/components/Page.tsx
+++ b/packages/next-starter/src/modules/core/components/Page.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { connect, useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Layout, Spin } from 'antd';
-import { useEffect, useState, useContext } from 'react';
-import { withRouter, WithRouterProps } from 'next/router';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 
 import { Header } from './Header';
 import { SidebarMenu } from './SidebarMenu';
@@ -10,46 +10,38 @@ import { ThemeProvider } from 'styled-components';
 import { theme } from './styles/GlobalStyles';
 import { Container, Inner } from './styles/Page';
 
-import { IWrapperPage, IStore, DefaultPubSubContext } from '@onr/core';
-import { authActions } from '@onr/auth';
+import { IWrapperPage, IStore } from '@onr/core';
 
 const { Content } = Layout;
 
-const NonDashboardRoutes = ['/auth/signin', '/auth/signup', '/auth/forgot', '/lockscreen', '/_error'];
-/* eslint-disable complexity*/
-const Component = (props: IWrapperPage.IProps & WithRouterProps) => {
-  const { router, menuItems, children } = props;
-  const state = props;
-  const dispatch = useDispatch();
+const NonDashboardRoutes = [
+  '/auth/signin',
+  '/auth/signup',
+  '/auth/forgot',
+  '/lockscreen',
+  '/_error',
+];
+/* eslint-disable complexity */
+export const Page = (props: IWrapperPage.IProps) => {
+  const { menuItems, children } = props;
+  const router = useRouter();
   const currentUser = useSelector((store: IStore) => store.authStore.currentUser);
+  const { boxed, darkSidebar, sidebarPopup, weakColor } = useSelector(
+    (store: IStore) => store.wrapper
+  );
   const [loading, setLoading] = useState(true);
   const isNotDashboard = router && NonDashboardRoutes.includes(router.pathname);
-  const { subscribe } = useContext(DefaultPubSubContext);
 
   useEffect(() => {
-    fetchData();
-
-    const unsub = subscribe('auth.updated', fetchData);
-
     setTimeout(() => {
       setLoading(false);
     }, 1000);
-
-    return unsub;
   }, [loading]);
-
-  async function fetchData() {
-    // dispatch(authActions.getCurrentUser());
-  }
 
   return (
     <Spin tip="Loading..." size="large" spinning={loading}>
       <ThemeProvider theme={theme}>
-        <Container
-          className={`${state.weakColor ? 'weakColor' : ''} ${
-            state.boxed ? 'boxed shadow-sm' : ''
-          }`}
-        >
+        <Container className={`${weakColor ? 'weakColor' : ''} ${boxed ? 'boxed shadow-sm' : ''}`}>
           {!isNotDashboard && <Header {...props} />}
           <Layout className="workspace">
             {!isNotDashboard && (
@@ -57,8 +49,8 @@ const Component = (props: IWrapperPage.IProps & WithRouterProps) => {
                 {...props}
                 currentUser={currentUser}
                 menuItems={menuItems}
-                sidebarTheme={state.darkSidebar ? 'dark' : 'light'}
-                sidebarMode={state.sidebarPopup ? 'vertical' : 'inline'}
+                sidebarTheme={darkSidebar ? 'dark' : 'light'}
+                sidebarMode={sidebarPopup ? 'vertical' : 'inline'}
               />
             )}
 
@@ -71,7 +63,3 @@ const Component = (props: IWrapperPage.IProps & WithRouterProps) => {
     </Spin>
   );
 };
-
-const mapStateToProps = (state: IStore) => state.wrapper;
-
-export const Page = withRouter(connect(mapStateToProps)(Component));

--- a/packages/next-starter/src/modules/core/components/SidebarMenu.tsx
+++ b/packages/next-starter/src/modules/core/components/SidebarMenu.tsx
@@ -14,10 +14,9 @@ import {
 } from 'antd';
 import { Book, LogOut, Triangle } from 'react-feather';
 import React, { useEffect } from 'react';
-import { withRouter, NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import { useDispatch, useSelector } from 'react-redux';
 import Link from 'next/link';
-import { connect } from 'react-redux';
-import { bindActionCreators, Dispatch } from 'redux';
 
 import { IUser } from '@onr/user';
 
@@ -26,17 +25,11 @@ import Inner from './styles/Sidebar';
 import { capitalize, lowercase } from '../../../lib/helpers';
 
 import { wrapperActions, IWrapperPage, IStore } from '@onr/core';
-import { useAuth, logout } from '@onr/auth';
+import { logout } from '@onr/auth';
 import { MenuItem } from '@app';
 
-import { useDispatch } from 'react-redux';
-
-declare type WithRouterProps = {
-  router: NextRouter;
-};
-
 /* eslint-disable complexity  */
-interface ISidebarMenuProps extends IWrapperPage.IProps, WithRouterProps {
+interface ISidebarMenuProps extends IWrapperPage.IProps {
   sidebarTheme: 'dark' | 'light';
   sidebarMode: 'vertical' | 'inline';
   menuItems: MenuItem[];
@@ -61,15 +54,26 @@ const UserMenu = (
   </Menu>
 );
 
-const SidebarContent = (props: ISidebarMenuProps) => {
+export const SidebarMenu = ({ menuItems, currentUser }: ISidebarMenuProps) => {
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const [openKeys, setOpenKeys] = React.useState<string[]>([]);
+  const [appRoutes, setAppRoutes] = React.useState(menuItems);
   const {
-    menuItems,
-    sidebarTheme,
+    name,
+    mobile,
+    mobileDrawer,
+    optionDrawer,
+    boxed,
+    darkSidebar,
     sidebarMode,
-    sidebarIcons,
+    sidebarTheme,
+    sidebarPopup,
     collapsed,
-    router,
-    currentUser,
+    sidebarIcons,
+    weakColor,
+  } = useSelector((store: IStore) => store.wrapper);
+  const {
     setOptionDrawer,
     setMobileDrawer,
     setBoxed,
@@ -78,12 +82,8 @@ const SidebarContent = (props: ISidebarMenuProps) => {
     setSidebarIcons,
     setCollapse,
     setWeak,
-  } = props;
-  const state = props;
-  const [openKeys, setOpenKeys] = React.useState<string[]>([]);
-  const [appRoutes, setAppRoutes] = React.useState(menuItems);
+  } = wrapperActions;
   const { pathname = '' } = router || {};
-  const dispatch = useDispatch();
 
   useEffect(() => {
     const roles = currentUser.roles || [];
@@ -98,7 +98,7 @@ const SidebarContent = (props: ISidebarMenuProps) => {
           }
         }
         return false;
-      }),
+      })
     );
   }, [currentUser?.roles]);
 
@@ -139,7 +139,7 @@ const SidebarContent = (props: ISidebarMenuProps) => {
                 className={pathname === route.path ? 'ant-menu-item-selected' : ''}
                 onClick={() => {
                   setOpenKeys([getKey(route.name, index)]);
-                  if (state.mobile) setMobileDrawer();
+                  if (mobile) dispatch(setMobileDrawer());
                 }}
               >
                 <Link href={route.path}>
@@ -168,7 +168,7 @@ const SidebarContent = (props: ISidebarMenuProps) => {
                       key={getKey(subitem.name, index)}
                       className={pathname === subitem.path ? 'ant-menu-item-selected' : ''}
                       onClick={() => {
-                        if (state.mobile) setMobileDrawer();
+                        if (mobile) dispatch(setMobileDrawer());
                       }}
                     >
                       <Link href={`${subitem.path ? subitem.path : ''}`}>
@@ -253,7 +253,7 @@ const SidebarContent = (props: ISidebarMenuProps) => {
   return (
     <>
       <Inner>
-        {!state.mobile && (
+        {!mobile && (
           <Sider
             width={240}
             className={`bg-${sidebarTheme}`}
@@ -268,8 +268,8 @@ const SidebarContent = (props: ISidebarMenuProps) => {
           closable={false}
           width={240}
           placement="left"
-          onClose={() => setMobileDrawer()}
-          visible={state.mobileDrawer}
+          onClose={() => dispatch(setMobileDrawer())}
+          visible={mobileDrawer}
           className="chat-drawer"
         >
           <Inner>
@@ -285,7 +285,7 @@ const SidebarContent = (props: ISidebarMenuProps) => {
                           display: 'inline',
                         }}
                       >
-                        {state.name}
+                        {name}
                       </strong>
                     </a>
                   </Link>
@@ -301,12 +301,17 @@ const SidebarContent = (props: ISidebarMenuProps) => {
           placement="right"
           closable={true}
           width={300}
-          onClose={() => setOptionDrawer()}
-          visible={state.optionDrawer}
+          onClose={() => dispatch(setOptionDrawer())}
+          visible={optionDrawer}
         >
           <List.Item
             actions={[
-              <Switch key={1} size="small" checked={!!state.boxed} onChange={() => setBoxed()} />,
+              <Switch
+                key={1}
+                size="small"
+                checked={!!boxed}
+                onChange={() => dispatch(setBoxed())}
+              />,
             ]}
           >
             <span style={ListItemSpanStylye}>Boxed view</span>
@@ -316,9 +321,9 @@ const SidebarContent = (props: ISidebarMenuProps) => {
               <Switch
                 key={1}
                 size="small"
-                checked={!!state.darkSidebar}
-                disabled={state.weakColor}
-                onChange={() => setSidebarTheme()}
+                checked={!!darkSidebar}
+                disabled={weakColor}
+                onChange={() => dispatch(setSidebarTheme())}
               />,
             ]}
           >
@@ -328,9 +333,9 @@ const SidebarContent = (props: ISidebarMenuProps) => {
             actions={[
               <Switch
                 size="small"
-                checked={!!state.sidebarPopup}
-                disabled={state.collapsed}
-                onChange={() => setSidebarPopup()}
+                checked={!!sidebarPopup}
+                disabled={collapsed}
+                onChange={() => dispatch(setSidebarPopup())}
                 key={1}
               />,
             ]}
@@ -342,9 +347,9 @@ const SidebarContent = (props: ISidebarMenuProps) => {
               <Switch
                 key={1}
                 size="small"
-                checked={!!state.sidebarIcons}
-                disabled={state.collapsed}
-                onChange={() => setSidebarIcons()}
+                checked={!!sidebarIcons}
+                disabled={collapsed}
+                onChange={() => dispatch(setSidebarIcons())}
               />,
             ]}
           >
@@ -355,8 +360,8 @@ const SidebarContent = (props: ISidebarMenuProps) => {
               <Switch
                 key={1}
                 size="small"
-                checked={!!state.collapsed}
-                onChange={() => setCollapse()}
+                checked={!!collapsed}
+                onChange={() => dispatch(setCollapse())}
               />,
             ]}
           >
@@ -367,8 +372,8 @@ const SidebarContent = (props: ISidebarMenuProps) => {
               <Switch
                 key={1}
                 size="small"
-                checked={!!state.weakColor}
-                onChange={() => setWeak()}
+                checked={!!weakColor}
+                onChange={() => dispatch(setWeak())}
               />,
             ]}
           >
@@ -379,18 +384,3 @@ const SidebarContent = (props: ISidebarMenuProps) => {
     </>
   );
 };
-
-const mapStateToProps = (state: IStore) => state.wrapper;
-
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  setOptionDrawer: bindActionCreators(wrapperActions.setOptionDrawer, dispatch),
-  setMobileDrawer: bindActionCreators(wrapperActions.setMobileDrawer, dispatch),
-  setBoxed: bindActionCreators(wrapperActions.setBoxed, dispatch),
-  setSidebarTheme: bindActionCreators(wrapperActions.setSidebarTheme, dispatch),
-  setSidebarPopup: bindActionCreators(wrapperActions.setSidebarPopup, dispatch),
-  setSidebarIcons: bindActionCreators(wrapperActions.setSidebarIcons, dispatch),
-  setCollapse: bindActionCreators(wrapperActions.setCollapse, dispatch),
-  setWeak: bindActionCreators(wrapperActions.setWeak, dispatch),
-});
-
-export const SidebarMenu = withRouter(connect(mapStateToProps, mapDispatchToProps)(SidebarContent));


### PR DESCRIPTION
* 把 core module 裡 `Header` component 中 Account 下拉選單抽出新的 component `AccountSelector`，放到 account module
* 再讓 `Header` component 的 `AccountSelector` 部份抽離出來，讓他可以接受一個 `HeaderMainSection` 的 component 當 Props，所以可由外面客製帶進去。
*  app module 去 import `AccountSelector `，再透過 `Page` component 一路將 `HeaderMainSection` 帶到 `Header` component 
* 順便把一些 component 用 Redux Hook 改寫