### PR TITLE
feat: application container

### DIFF
--- a/packages/next-starter/src/app/components/MyApp.tsx
+++ b/packages/next-starter/src/app/components/MyApp.tsx
@@ -8,15 +8,22 @@ import Head from 'next/head';
 import Router from 'next/router';
 import { start, done } from 'nprogress';
 
-import { AppProvider } from '@onr/core';
+import { AppProvider, createApp, OnrApp } from '@onr/core';
 import { store, afterComponentDidMount } from '../redux';
 
 import { PageContainer } from './PageContainer';
 import { GlobalStyles } from './GlobalStyles';
+import { menuItems } from '../configs';
 
 const makeStore: MakeStore = (context: Context) => store();
 
 const wrapper = createWrapper(makeStore, { debug: false });
+
+const app: OnrApp = createApp({
+  routes: menuItems,
+});
+
+const NewAppProvider = app.getProvider();
 
 Router.events.on('routeChangeStart', () => start());
 Router.events.on('routeChangeComplete', () => done());
@@ -80,7 +87,9 @@ export class AppComponent extends Component<AppProps> {
           )}
         </Head>
         <AppProvider>
-          <PageContainer {...this.props} />
+          <NewAppProvider>
+            <PageContainer {...this.props} />
+          </NewAppProvider>
         </AppProvider>
       </>
     );

--- a/packages/next-starter/src/app/components/PageContainer.tsx
+++ b/packages/next-starter/src/app/components/PageContainer.tsx
@@ -1,23 +1,14 @@
-import React from 'react';
-
 import { AppProps } from 'next/app';
 import { Page } from '@onr/core';
 import { AuthWrapper, logout } from '@onr/auth';
 import { AccountSelector } from '@onr/account';
-import { menuItems } from '../';
 import { theme } from './GlobalStyles';
 
 const Container: React.FC = (props: AppProps) => {
   const { Component, pageProps } = props;
 
   return (
-    <Page
-      {...props}
-      theme={theme}
-      logout={logout}
-      menuItems={menuItems}
-      HeaderMainSection={AccountSelector}
-    >
+    <Page {...props} theme={theme} logout={logout} HeaderMainSection={AccountSelector}>
       <Component {...pageProps} />
     </Page>
   );

--- a/packages/onr-core/src/components/App.tsx
+++ b/packages/onr-core/src/components/App.tsx
@@ -1,0 +1,35 @@
+import { createContext, FC, ReactNode } from 'react';
+import { AppComponents, FullAppOptions, OnrApp } from '../types';
+
+export const AppContext = createContext(null);
+
+type ProviderProps = {
+  children?: ReactNode;
+};
+
+export class App implements OnrApp {
+  private readonly components: AppComponents;
+  private readonly routes: any;
+
+  constructor(options: FullAppOptions) {
+    this.components = options.components;
+    this.routes = options.routes;
+  }
+
+  getComponents(): AppComponents {
+    return this.components;
+  }
+
+  getProvider() {
+    // eslint-disable-next-line
+    const Provider: FC = ({ children }: ProviderProps): JSX.Element => {
+      return <AppContext.Provider value={this}>{children}</AppContext.Provider>;
+    };
+
+    return Provider;
+  }
+
+  getRoutes() {
+    return this.routes;
+  }
+}

--- a/packages/onr-core/src/components/index.ts
+++ b/packages/onr-core/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './layout';
+export * from './App';

--- a/packages/onr-core/src/components/layout/Page/Page.tsx
+++ b/packages/onr-core/src/components/layout/Page/Page.tsx
@@ -29,7 +29,7 @@ const NonDashboardRoutes = [
 ];
 /* eslint-disable complexity */
 export const Page = (props: Props) => {
-  const { HeaderMainSection, menuItems, theme, logout, children } = props;
+  const { HeaderMainSection, theme, logout, children } = props;
   const router = useRouter();
   const currentUser = useSelector((store: CoreStore) => store.authStore.currentUser);
   const { boxed, darkSidebar, sidebarPopup, weakColor } = useSelector(
@@ -54,7 +54,6 @@ export const Page = (props: Props) => {
               <SidebarMenu
                 logout={logout}
                 currentUser={currentUser}
-                menuItems={menuItems}
                 sidebarTheme={darkSidebar ? 'dark' : 'light'}
                 sidebarMode={sidebarPopup ? 'vertical' : 'inline'}
               />

--- a/packages/onr-core/src/components/layout/SidebarMenu/SidebarMenu.tsx
+++ b/packages/onr-core/src/components/layout/SidebarMenu/SidebarMenu.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
 } from 'antd';
 import { Book, LogOut, Triangle } from 'react-feather';
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { capitalize } from 'lodash';
@@ -24,6 +24,7 @@ import { coreActions, CoreStore } from '../../../redux';
 import { AuthUser } from '../../../types';
 import { DashHeader } from '../Header';
 import { Sidebar } from './styles';
+import { AppContext } from '../../App';
 
 /* eslint-disable complexity  */
 interface Props {
@@ -52,9 +53,11 @@ const UserMenu = (
   </Menu>
 );
 
-export const SidebarMenu = ({ menuItems, currentUser, logout }: Props) => {
+export const SidebarMenu = ({ currentUser, logout }: Props) => {
   const dispatch = useDispatch();
   const router = useRouter();
+  const app = useContext(AppContext);
+  const menuItems = app.getRoutes();
   const [openKeys, setOpenKeys] = React.useState<string[]>([]);
   const [appRoutes, setAppRoutes] = React.useState(menuItems);
   const {

--- a/packages/onr-core/src/index.ts
+++ b/packages/onr-core/src/index.ts
@@ -2,3 +2,4 @@ export * from './components';
 export * from './hooks';
 export * from './redux';
 export * from './types';
+export * from './wrappers';

--- a/packages/onr-core/src/types/AppComponents.ts
+++ b/packages/onr-core/src/types/AppComponents.ts
@@ -1,0 +1,23 @@
+import { ComponentType } from 'react';
+
+export type AppComponents = {
+  NotFoundErrorPage: ComponentType<{}>;
+
+  /**
+   * An optional sign-in page that will be rendered instead of the AppRouter at startup.
+   *
+   * If a sign-in page is set, it will always be shown before the app, and it is up
+   * to the sign-in page to handle e.g. saving of login methods for subsequent visits.
+   *
+   * The sign-in page will be displayed until it has passed up a result to the parent,
+   * and which point the AppRouter and all of its children will be rendered instead.
+   */
+  SignInPage?: ComponentType<SignInPageProps>;
+};
+
+export type SignInPageProps = {
+  /**
+   * Set the sign-in result for the app. This should only be called once.
+   */
+  onResult(result: {}): void;
+};

--- a/packages/onr-core/src/types/AppOptions.ts
+++ b/packages/onr-core/src/types/AppOptions.ts
@@ -1,0 +1,9 @@
+import { AppComponents } from './AppComponents';
+
+export type AppOptions = {
+  /**
+   * Supply components to the app to override the default ones.
+   */
+  components?: Partial<AppComponents>;
+  routes?: any;
+};

--- a/packages/onr-core/src/types/OnrApp.ts
+++ b/packages/onr-core/src/types/OnrApp.ts
@@ -1,0 +1,8 @@
+import { AppComponents } from './AppComponents';
+
+export type OnrApp = {};
+
+export type FullAppOptions = {
+  components: AppComponents;
+  routes: any;
+};

--- a/packages/onr-core/src/types/index.ts
+++ b/packages/onr-core/src/types/index.ts
@@ -1,1 +1,4 @@
+export * from './AppComponents';
+export * from './AppOptions';
 export * from './AuthUser';
+export * from './OnrApp';

--- a/packages/onr-core/src/wrappers/createApp.tsx
+++ b/packages/onr-core/src/wrappers/createApp.tsx
@@ -1,0 +1,22 @@
+import { App } from '../components';
+import { AppOptions } from '../types';
+
+/**
+ * Creates a new Backstage App.
+ */
+export function createApp(options?: AppOptions) {
+  // TODO: should create a DefaultNotFoundPage
+  const DefaultNotFoundPage = () => <div>PAGE NOT FOUND</div>;
+
+  const components = {
+    NotFoundErrorPage: DefaultNotFoundPage,
+    ...options?.components,
+  };
+
+  const app = new App({
+    components,
+    routes: options?.routes,
+  });
+
+  return app;
+}

--- a/packages/onr-core/src/wrappers/index.ts
+++ b/packages/onr-core/src/wrappers/index.ts
@@ -1,0 +1,1 @@
+export * from './createApp';


### PR DESCRIPTION
- create a `App` container, it can accept
  - components
    - NotFoundErrorPage
    - SignInPage
  - routes aka `menuItems`
- create a `AppContext`, so any components inside the AppProvider can get the whole app container.  
- create a wrapper `createApp` function which is a factory method to create an app container
- `MyApp` can use `createApp` to create a app container, and then use the AppProvider wrap the PageContainer.

#40 