### PR TITLE
feat: remove env from @onr/common

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "lerna run lint --parallel",
     "format": "lerna run format --parallel",
     "test": "lerna run test --parallel",
+    "prepublishOnly": "yarn build",
     "postinstall": "husky install"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "dev": "lerna run dev --parallel",
+    "build": "lerna run build --parallel",
     "lint": "lerna run lint --parallel",
     "format": "lerna run format --parallel",
     "test": "lerna run test --parallel",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -26,6 +26,7 @@
     "lint": "prettier -c 'src/**/*'; eslint src --ext .ts,.tsx",
     "format": "prettier --write 'src/**/*'; eslint src --fix --ext .ts,.tsx",
     "build": "tsc",
+    "prepublishOnly": "yarn build",
     "test": "jest --coverage --passWithNoTests"
   },
   "bugs": {

--- a/packages/next-starter/src/app/components/MyApp.tsx
+++ b/packages/next-starter/src/app/components/MyApp.tsx
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import Router from 'next/router';
 import { done, start } from 'nprogress';
 import React, { Component } from 'react';
-import { menuItems } from '../configs';
+import { appConfig, menuItems } from '../configs';
 import { afterComponentDidMount, store } from '../redux';
 import { GlobalStyles } from './GlobalStyles';
 import { PageContainer } from './PageContainer';
@@ -15,6 +15,7 @@ const makeStore: MakeStore = (context: Context) => store();
 const wrapper = createWrapper(makeStore, { debug: false });
 
 const app: OnrApp = createApp({
+  appConfig,
   routes: menuItems,
 });
 

--- a/packages/next-starter/src/app/configs/appConfig.ts
+++ b/packages/next-starter/src/app/configs/appConfig.ts
@@ -1,0 +1,9 @@
+import getConfig from 'next/config';
+const { publicRuntimeConfig } = getConfig() as {
+  publicRuntimeConfig: Record<'processEnv' | string, unknown>;
+};
+
+export const appConfig = {
+  apiBaseUrl: `${publicRuntimeConfig.processEnv.NEXT_PUBLIC_API_URL}/api`,
+  apiKey: publicRuntimeConfig.processEnv.NEXT_PUBLIC_API_KEY || '',
+};

--- a/packages/next-starter/src/app/configs/index.ts
+++ b/packages/next-starter/src/app/configs/index.ts
@@ -1,1 +1,2 @@
+export * from './appConfig';
 export * from './menuItems';

--- a/packages/onr-common/package.json
+++ b/packages/onr-common/package.json
@@ -26,6 +26,7 @@
     "lint": "prettier -c 'src/**/*'; eslint src --ext .ts,.tsx",
     "format": "prettier --write 'src/**/*'; eslint src --fix --ext .ts,.tsx",
     "build": "tsc",
+    "prepublishOnly": "yarn build",
     "test": "jest --coverage --passWithNoTests"
   },
   "bugs": {

--- a/packages/onr-common/src/services/Http.ts
+++ b/packages/onr-common/src/services/Http.ts
@@ -1,6 +1,6 @@
-import { stringify } from 'qs';
-import Axios, { AxiosResponse, AxiosError } from 'axios';
+import Axios, { AxiosError, AxiosResponse } from 'axios';
 import getConfig from 'next/config';
+import { stringify } from 'qs';
 
 declare type RequestMethods =
   | 'get'
@@ -39,8 +39,8 @@ interface ResponsePayload<T> {
 }
 
 interface Http {
-  baseUrl: string;
-  apiToken: string;
+  baseUrl: string | null;
+  apiToken: string | null;
   setBaseUrl: (ur: string) => void;
   setToken: (token: string) => void;
   request: <T, K = EmptyObject>(payload: RequestPayload) => Promise<ResponsePayload<T> & K>;
@@ -80,10 +80,12 @@ if (!('processEnv' in publicRuntimeConfig) || !hasProcessEnv(publicRuntimeConfig
 }
 
 const HTTP: Http = {
-  baseUrl: `${publicRuntimeConfig.processEnv.NEXT_PUBLIC_API_URL}/api`,
-  apiToken: publicRuntimeConfig.processEnv.NEXT_PUBLIC_API_KEY || '',
+  baseUrl: null,
+  apiToken: null,
 
-  setBaseUrl: (url: string): string => (HTTP.baseUrl = url),
+  setBaseUrl: (url: string): void => {
+    HTTP.baseUrl = url;
+  },
 
   setToken(token: string): void {
     HTTP.apiToken = token;

--- a/packages/onr-core/package.json
+++ b/packages/onr-core/package.json
@@ -31,6 +31,9 @@
   "bugs": {
     "url": "https://github.com/OnrampLab/onr-react-ui/issues"
   },
+  "dependencies": {
+    "@onr/common": "^0.4.4"
+  },
   "peerDependencies": {
     "antd": "^4.16.1",
     "lodash": "^4.14.0",

--- a/packages/onr-core/package.json
+++ b/packages/onr-core/package.json
@@ -26,6 +26,7 @@
     "lint": "prettier -c 'src/**/*'; eslint src --ext .ts,.tsx",
     "format": "prettier --write 'src/**/*'; eslint src --fix --ext .ts,.tsx",
     "build": "tsc",
+    "prepublishOnly": "yarn build",
     "test": "jest --coverage --passWithNoTests"
   },
   "bugs": {

--- a/packages/onr-core/src/components/App.tsx
+++ b/packages/onr-core/src/components/App.tsx
@@ -1,7 +1,8 @@
+import { Http } from '@onr/common';
 import { createContext, FC, ReactNode } from 'react';
 import { AppComponents, FullAppOptions, OnrApp } from '../types';
 
-export const AppContext = createContext(null);
+export const AppContext = createContext<any | null>(null);
 
 type ProviderProps = {
   children?: ReactNode;
@@ -9,11 +10,18 @@ type ProviderProps = {
 
 export class App implements OnrApp {
   private readonly components: AppComponents;
+  private readonly appConfig: any;
   private readonly routes: any;
 
   constructor(options: FullAppOptions) {
     this.components = options.components;
+    this.appConfig = options.appConfig;
     this.routes = options.routes;
+  }
+
+  initialize() {
+    Http.setBaseUrl(this.appConfig.apiBaseUrl);
+    Http.setToken(this.appConfig.apiKey);
   }
 
   getComponents(): AppComponents {
@@ -27,6 +35,10 @@ export class App implements OnrApp {
     };
 
     return Provider;
+  }
+
+  getAppConfig() {
+    return this.appConfig;
   }
 
   getRoutes() {

--- a/packages/onr-core/src/components/layout/AppProvider.tsx
+++ b/packages/onr-core/src/components/layout/AppProvider.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { usePubSub } from '../../hooks';
 
 export const AppProvider = props => {

--- a/packages/onr-core/src/components/layout/Header/Header.tsx
+++ b/packages/onr-core/src/components/layout/Header/Header.tsx
@@ -1,20 +1,18 @@
-import React from 'react';
 import { Avatar, Layout, Menu } from 'antd';
+import Link from 'next/link';
+import React, { ReactNode } from 'react';
 import { BarChart, Settings, Triangle } from 'react-feather';
 import { useDispatch, useSelector } from 'react-redux';
-import Link from 'next/link';
-
 import { coreActions, CoreStore } from '../../../redux';
-
 import { DashHeader } from './styles';
 
 const { SubMenu } = Menu;
 
 type Props = {
-  HeaderMainSection: React.Component;
+  HeaderMainSection: ReactNode;
 };
 
-export const Header: React.FC = ({ HeaderMainSection }: Props) => {
+export const Header: React.FC<Props> = ({ HeaderMainSection }: Props) => {
   const dispatch = useDispatch();
   const { name, mobile } = useSelector((store: CoreStore) => store.coreStore);
 
@@ -33,7 +31,7 @@ export const Header: React.FC = ({ HeaderMainSection }: Props) => {
           </a>
         </Link>
 
-        <HeaderMainSection />
+        {HeaderMainSection}
 
         <span className="mr-auto" />
         <Menu mode="horizontal">

--- a/packages/onr-core/src/components/layout/Page/Page.tsx
+++ b/packages/onr-core/src/components/layout/Page/Page.tsx
@@ -1,18 +1,15 @@
+import { Layout, Spin } from 'antd';
+import { useRouter } from 'next/router';
 import { FC, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { AnyAction } from 'redux';
-import { Layout, Spin } from 'antd';
-import { useRouter } from 'next/router';
 import { ThemeProvider } from 'styled-components';
 import { Header, SidebarMenu } from '../';
-
 import { CoreStore } from '../../../redux';
-
 import { Container, Inner } from './styles';
 
 interface Props {
   children: JSX.Element;
-  menuItems: any[];
   theme: any;
   HeaderMainSection: FC;
   logout: () => AnyAction;

--- a/packages/onr-core/src/components/layout/SidebarMenu/SidebarMenu.tsx
+++ b/packages/onr-core/src/components/layout/SidebarMenu/SidebarMenu.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import {
   Avatar,
   Badge,
@@ -12,25 +13,23 @@ import {
   Switch,
   Tooltip,
 } from 'antd';
-import { Book, LogOut, Triangle } from 'react-feather';
-import React, { useEffect, useContext } from 'react';
-import { useRouter } from 'next/router';
-import Link from 'next/link';
 import { capitalize } from 'lodash';
-import { AnyAction } from 'redux';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import React, { useContext, useEffect } from 'react';
+import { Book, LogOut, Triangle } from 'react-feather';
 import { useDispatch, useSelector } from 'react-redux';
-
+import { AnyAction } from 'redux';
 import { coreActions, CoreStore } from '../../../redux';
 import { AuthUser } from '../../../types';
+import { AppContext } from '../../App';
 import { DashHeader } from '../Header';
 import { Sidebar } from './styles';
-import { AppContext } from '../../App';
 
 /* eslint-disable complexity  */
 interface Props {
   sidebarTheme: 'dark' | 'light';
   sidebarMode: 'vertical' | 'inline';
-  menuItems: any[];
   currentUser: AuthUser;
   logout: () => AnyAction;
 }
@@ -53,7 +52,7 @@ const UserMenu = (
   </Menu>
 );
 
-export const SidebarMenu = ({ currentUser, logout }: Props) => {
+export const SidebarMenu = ({ currentUser, logout, sidebarMode, sidebarTheme }: Props) => {
   const dispatch = useDispatch();
   const router = useRouter();
   const app = useContext(AppContext);

--- a/packages/onr-core/src/types/AppOptions.ts
+++ b/packages/onr-core/src/types/AppOptions.ts
@@ -5,5 +5,6 @@ export type AppOptions = {
    * Supply components to the app to override the default ones.
    */
   components?: Partial<AppComponents>;
+  appConfig?: any;
   routes?: any;
 };

--- a/packages/onr-core/src/types/OnrApp.ts
+++ b/packages/onr-core/src/types/OnrApp.ts
@@ -4,5 +4,6 @@ export type OnrApp = {};
 
 export type FullAppOptions = {
   components: AppComponents;
+  appConfig: any;
   routes: any;
 };

--- a/packages/onr-core/src/wrappers/createApp.tsx
+++ b/packages/onr-core/src/wrappers/createApp.tsx
@@ -15,8 +15,11 @@ export function createApp(options?: AppOptions) {
 
   const app = new App({
     components,
+    appConfig: options?.appConfig,
     routes: options?.routes,
   });
+
+  app.initialize();
 
   return app;
 }

--- a/packages/tailwind-palette/package.json
+++ b/packages/tailwind-palette/package.json
@@ -25,6 +25,7 @@
     "lint": "prettier -c 'src/**/*'; eslint src --ext .ts,.tsx",
     "format": "prettier --write 'src/**/*'; eslint src --fix --ext .ts,.tsx",
     "build": "tsc",
+    "prepublishOnly": "yarn build",
     "test": "jest --coverage --passWithNoTests"
   },
   "bugs": {


### PR DESCRIPTION
## Implementation

- 讓 `@onr/core` 的 `App` container 可以帶 appConfig，並在初始化時去設定 api base url & api key.
- 在 `next-starter` 新增 appConfig 去讀取 env
- 讓 `next-starter` 的 `MyApp` 去把 appConfig 帶入給 `createApp` function 去產生 `App`
- 修正 `@onr/core` tsc build 失敗的問題
- 修正在使用 lerna publish 時，沒有 build bundle 的問題

References:

- [npm life cycle scripts](https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts)
- [Why does lerna run “prepublish” when bootstrapping?](https://stackoverflow.com/questions/55489791/why-does-lerna-run-prepublish-when-bootstrapping)
![1st Generation](https://user-images.githubusercontent.com/1978357/123658339-360bbc00-d864-11eb-9b23-ee8f8e4a8654.png)
![2nd Generation](https://user-images.githubusercontent.com/1978357/123658346-373ce900-d864-11eb-96b6-da8271e3a3d7.png)

#19 